### PR TITLE
Fix: E1208: -complete used without -nargs

### DIFF
--- a/plugin/sayonara.vim
+++ b/plugin/sayonara.vim
@@ -184,4 +184,4 @@ function! s:sayonara(do_preserve)
 endfunction
 " }}}
 
-command! -nargs=0 -complete=buffer -bang -bar Sayonara call s:sayonara(<bang>0)
+command! -bang -bar Sayonara call s:sayonara(<bang>0)


### PR DESCRIPTION
In newest VIM version, the command `Sayonara` is not created because of the error E1208. 

Please check my PR, thanks.