### PR TITLE
Fix E1208 error

### DIFF
--- a/plugin/sayonara.vim
+++ b/plugin/sayonara.vim
@@ -184,4 +184,4 @@ function! s:sayonara(do_preserve)
 endfunction
 " }}}
 
-command! -nargs=0 -complete=buffer -bang -bar Sayonara call s:sayonara(<bang>0)
+command! -bang -bar Sayonara call s:sayonara(<bang>0)


### PR DESCRIPTION
similar issue: https://github.com/jremmen/vim-ripgrep/pull/56

Argument parsing seems to have changed in Vim, and `complete` and `nargs` aren't working as before. I don't think Sayonara needs `-complete=buffer` and removing it makes the error on startup go away.