### PR TITLE
Fix E1208: -complete used without allowing arguments

### DIFF
--- a/plugin/sayonara.vim
+++ b/plugin/sayonara.vim
@@ -184,4 +184,4 @@ function! s:sayonara(do_preserve)
 endfunction
 " }}}
 
-command! -nargs=0 -complete=buffer -bang -bar Sayonara call s:sayonara(<bang>0)
+command! -nargs=? -complete=buffer -bang -bar Sayonara call s:sayonara(<bang>0)


### PR DESCRIPTION
The following errors have been fixed at startup.

E1208: -complete used without allowing arguments
